### PR TITLE
Fixed broken JSHint support

### DIFF
--- a/lib/jshint-linter.js
+++ b/lib/jshint-linter.js
@@ -1,5 +1,8 @@
-var jslintLinter = require('./jslint-linter');
-
-module.exports = Object.create(jslintLinter, {
-  linter: { value: { check: require("../vendor/jshint").JSHINT } }
-});
+module.exports = require('./jslint-linter');
+module.exports.create = function(options) {
+  if (!options) { throw new TypeError('options is required (at least an empty object)'); }
+  return Object.create(this, {
+    options: { value: options },
+    linter: { value: { check: require('../vendor/jshint').JSHINT } }
+  });
+};


### PR DESCRIPTION
Couldn't get it to work with jshint by setting the option "linter" to "jshint" (it was ignored and jslint was executed). So I added a fix in jshint-linter.js that fixed the problem for me.
