### PR TITLE
Export "proper" module index

### DIFF
--- a/lib/autolint.js
+++ b/lib/autolint.js
@@ -1,0 +1,4 @@
+module.exports = {
+  configuration: require("./configuration"),
+  linter: require("./linter")
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "autolint",
     "version": "1.0.2",
-    "main": "./bin/autolint",
+    "main": "./lib/autolint",
     "description": "Autolint watches your files for jslint-errors.",
     "author": "Magnar Sveen <magnars@gmail.com>",
     "repository": {


### PR DESCRIPTION
- Makes it easier to reuse parts of autolint in other projects
- The module index may need to export other objects too, I'm not
  entirely sure which ones are useful to require outside autolint
