### PR TITLE
Bug fix about a problem with the configuration file

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -6,7 +6,7 @@ var defaultConfig = require("./default-configuration");
 
 module.exports = {
   exists: function () {
-    return path.existsSync("./autolint.js");
+    return path.existsSync("./autolintconfig.js");
   },
 
   defaultsPlus: function (config) {
@@ -20,16 +20,16 @@ module.exports = {
   },
 
   load: function () {
-    var fileConfig = require(process.cwd() + "/autolint");
+    var fileConfig = require(process.cwd() + "/autolintconfig");
     return this.defaultsPlus(fileConfig);
   },
 
   createDefaultConfigFile: function () {
     if (this.exists()) {
-      throw new Error("autolint.js already exists in " + process.cwd());
+      throw new Error("autolintconfig.js already exists in " + process.cwd());
     }
 
-    var newFile = fs.createWriteStream('./autolint.js');
+    var newFile = fs.createWriteStream('./autolintconfig.js');
     var oldFile = fs.createReadStream(__dirname + '/blank-config-file.js');
 
     newFile.once('open', function () {


### PR DESCRIPTION
This is a fix for a problem with the configuration file. When autolint
is started for the first time, it will generate a file named
autolint.js. But when for the second time the autolint command is
called, it will try to execute the javascript-file instead of the
command. This is fixed by changing the name of the configuration file so
it doesn't match anymore with the name of the command. Here is the
configuration file called autolintconfig.js.
