### PR TITLE
Sigint fix windows

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -6,7 +6,7 @@ var defaultConfig = require("./default-configuration");
 
 module.exports = {
   exists: function () {
-    return path.existsSync("./autolint.js");
+    return path.existsSync("./autolintconfig.js");
   },
 
   defaultsPlus: function (config) {
@@ -20,16 +20,16 @@ module.exports = {
   },
 
   load: function () {
-    var fileConfig = require(process.cwd() + "/autolint");
+    var fileConfig = require(process.cwd() + "/autolintconfig");
     return this.defaultsPlus(fileConfig);
   },
 
   createDefaultConfigFile: function () {
     if (this.exists()) {
-      throw new Error("autolint.js already exists in " + process.cwd());
+      throw new Error("autolintconfig.js already exists in " + process.cwd());
     }
 
-    var newFile = fs.createWriteStream('./autolint.js');
+    var newFile = fs.createWriteStream('./autolintconfig.js');
     var oldFile = fs.createReadStream(__dirname + '/blank-config-file.js');
 
     newFile.once('open', function () {

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -6,7 +6,7 @@ var defaultConfig = require("./default-configuration");
 
 module.exports = {
   exists: function () {
-    return path.existsSync("./autolintconfig.js");
+    return path.existsSync("./autolint.js");
   },
 
   defaultsPlus: function (config) {
@@ -20,16 +20,16 @@ module.exports = {
   },
 
   load: function () {
-    var fileConfig = require(process.cwd() + "/autolintconfig");
+    var fileConfig = require(process.cwd() + "/autolint");
     return this.defaultsPlus(fileConfig);
   },
 
   createDefaultConfigFile: function () {
     if (this.exists()) {
-      throw new Error("autolintconfig.js already exists in " + process.cwd());
+      throw new Error("autolint.js already exists in " + process.cwd());
     }
 
-    var newFile = fs.createWriteStream('./autolintconfig.js');
+    var newFile = fs.createWriteStream('./autolint.js');
     var oldFile = fs.createReadStream(__dirname + '/blank-config-file.js');
 
     newFile.once('open', function () {

--- a/lib/on-interrupt.js
+++ b/lib/on-interrupt.js
@@ -1,14 +1,30 @@
 module.exports = function (message, callback) {
   var interrupted = false;
-  process.on('exit', function () {
-    if (interrupted) {
-      process.exit();
-    }
-    console.log(message + " Interrupt a second time to quit");
-    interrupted = true;
-    setTimeout(function () {
-      interrupted = false;
-      callback();
-    }, 1500);
-  });
+  try{
+	  process.on('SIGINT', function () {
+		if (interrupted) {
+		  process.exit();
+		}
+		console.log(message + " Interrupt a second time to quit");
+		interrupted = true;
+		setTimeout(function () {
+		  interrupted = false;
+		  callback();
+		}, 1500);
+	  });
+  }
+  catch(err){
+	//fallback for windows because windows doesn't know the signal SIGINT
+	process.on('exit', function () {
+		if (interrupted) {
+		  process.exit();
+		}
+		console.log(message + " Interrupt a second time to quit");
+		interrupted = true;
+		setTimeout(function () {
+		  interrupted = false;
+		  callback();
+		}, 1500);
+	  });
+  }
 };

--- a/lib/on-interrupt.js
+++ b/lib/on-interrupt.js
@@ -1,30 +1,17 @@
 module.exports = function (message, callback) {
-  var interrupted = false;
-  try{
-	  process.on('SIGINT', function () {
-		if (interrupted) {
-		  process.exit();
-		}
-		console.log(message + " Interrupt a second time to quit");
-		interrupted = true;
-		setTimeout(function () {
-		  interrupted = false;
-		  callback();
-		}, 1500);
-	  });
-  }
-  catch(err){
-	//fallback for windows because windows doesn't know the signal SIGINT
-	process.on('exit', function () {
-		if (interrupted) {
-		  process.exit();
-		}
-		console.log(message + " Interrupt a second time to quit");
-		interrupted = true;
-		setTimeout(function () {
-		  interrupted = false;
-		  callback();
-		}, 1500);
-	  });
-  }
+  var interrupted = false
+	,platform = process.platform
+	,signal = (platform.indexOf('win') !== -1)?"exit":"SIGINT";
+  //exit signal when platform is exit, otherwise SIGINT signal
+  process.on(signal, function () {
+	if (interrupted) {
+	  process.exit();
+	}
+	console.log(message + " Interrupt a second time to quit");
+	interrupted = true;
+	setTimeout(function () {
+	  interrupted = false;
+	  callback();
+	}, 1500);
+  });
 };

--- a/lib/on-interrupt.js
+++ b/lib/on-interrupt.js
@@ -1,6 +1,6 @@
 module.exports = function (message, callback) {
   var interrupted = false;
-  process.on('SIGINT', function () {
+  process.on('exit', function () {
     if (interrupted) {
       process.exit();
     }


### PR DESCRIPTION
This fix handles the problem about the SIGINT signal that is not known
in Windows because this is a signal specific for Linux. This can be
fixed by changing the signal to 'exit'. (I have also reverted the commit about the configuration file here)

By my opinion, it is best that you make an extra branch for Windows because it is specific for Windows. I think this fix will create a problem in Linux. (but I'm not sure)
